### PR TITLE
Fix dockerise.sh to not use user input

### DIFF
--- a/archive/dockerise.sh
+++ b/archive/dockerise.sh
@@ -1,9 +1,6 @@
-# dockerfile to build the archive docker
-
 source .env
 
-read -p 'AWS Account ID: ' AWS_ACCOUNT_ID
-read -p 'AWS Region: ' AWS_REGION
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 


### PR DESCRIPTION
The title is self-explanatory. This is a short push to not require user input when dockerising and sending the image to an ECR.

Closes #114. 