### PR TITLE
Fix bash start.sh and terraform bugs

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,9 +21,9 @@ terraform init
 
 log "🌱 Applying ECR repositories only..."
 terraform apply -auto-approve \
-    -target=aws_ecr_repository.c21-charn-pipeline-ecr \
-    -target=aws_ecr_repository.c21-charn-dashboard-ecr \
-    -target=aws_ecr_repository.c21-charn-archive-ecr
+    -target=aws_ecr_repository.charn-pipeline-ecr \
+    -target=aws_ecr_repository.charn-dashboard-ecr \
+    -target=aws_ecr_repository.charn-archive-ecr
 
 cd ..
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,3 +41,7 @@ variable "DB_PASSWORD" {
 variable "S3_BUCKET" {
   type = string
 }
+
+variable "AWS_ACCOUNT_ID" {
+  type = string
+}


### PR DESCRIPTION
The start.sh script did not refer to the correct names of the eccr repositories, which led to a whole host of other terraform issues, which are now fixed. (Or at least should be)

closes #140 